### PR TITLE
Writing fixes: honest verbs, specific bullets, no filler

### DIFF
--- a/resume.tex
+++ b/resume.tex
@@ -23,10 +23,10 @@
 
 \section{Experience}
 \textbf{\href{}{\runsubsection{Founding Mobile Engineer |}}} 
-\descript{Barkie.ai \datetext{June '25 – Oct '25}}
+\descript{Barkie.ai \datetext{Jun '25 – Oct '25}}
 \begin{tightemize}
-\item Architected the iOS beta in \emphitalic{SwiftUI}, delivering a \emphitalic{HIG}-compliant UI and establishing the core product foundation.
-\item Engineered an on-device \emphitalic{CoreML} vision model to automate scorecard scanning and integrate directly with the GHIN API.
+\item Built the iOS beta from scratch in \emphitalic{SwiftUI}, shipping a \emphitalic{HIG}-compliant UI as the sole mobile engineer.
+\item Trained a \emphitalic{CoreML} vision model to scan scorecards on-device and sync results with the GHIN API.
 \item Implemented CI/CD pipelines for automated builds, testing, and beta deployments to \emphitalic{TestFlight}.
 \end{tightemize}
 % \sectionsep
@@ -36,29 +36,29 @@
 \descript{GOJEK \datetext{May '22 – Aug '24}}
 \begin{tightemize}
     \item Revamped Help Center UI using \emphitalic{UIKit}, improving usability and reducing support queries by \italictext{15\%}.
-    \item Led crucial iOS initiatives for Help Center by collaborating seamlessly with Android, backend, and product teams.
+    \item Drove Help Center feature rollouts across iOS, coordinating with Android, backend, and product teams.
     \item Built a Pin-based Auth SDK in \emphitalic{Swift} with \emphitalic{VIPER}, enabling a unified experience across GoTo apps
-    \item Worked on the GoPay app in \emphitalic{Flutter}, supporting \italictext{130M daily users} with an enhanced user experience.
+    \item Shipped features on the GoPay \emphitalic{Flutter} app, serving \italictext{130M daily users}.
     \item Implemented a \emphitalic{Server Driven UI} for GoPay's homepage, enabling dynamic updates without app releases.
     \item Integrated in-house analytics framework utilizing \emphitalic{ProtoBuffs}, reducing third-party dependencies and cutting costs by 30\%.
 \end{tightemize}
 % \sectionsep
 
 \textbf{\href{https://summerofcode.withgoogle.com/projects/6623823417311232}{\runsubsection{iOS Developer |}}} 
-\descript{Google Summer of Code - VideoLAN \datetext{June '21 – Aug '21}}
+\descript{Google Summer of Code - VideoLAN \datetext{Jun '21 – Aug '21}}
 \begin{tightemize}
-    \item Worked on the "Continue Watching" feature in VLC media player for iOS, enhancing user retention and engagement.
-    \item Worked with the \emphitalic{legacy codebase} and understanding \emphitalic{Objective-C} to fix bugs and implement features.
-    \item Improved UI/UX using \emphitalic{UIKit}, aligning with Apple's design guidelines for a more intuitive user experience.
+    \item Built the "Continue Watching" feature in VLC for iOS, letting users resume playback across sessions.
+    \item Fixed bugs and added features in VLC's \emphitalic{Objective-C} codebase.
+    \item Redesigned screens in \emphitalic{UIKit} to match Apple's Human Interface Guidelines.
     % \item Participated in code reviews, ensuring adherence to best practices and maintaining code quality.
     % \item Contributed to documentation, improving onboarding for new developers in the VideoLAN community.
 \end{tightemize}
 % \sectionsep
 
 \textbf{\href{}{\runsubsection{Head of Open Source and Mobile Tech |}}} 
-\descript{IoSD \datetext{June '20 – June '21}}
+\descript{IoSD \datetext{Jun '20 – Jun '21}}
 \begin{tightemize}
-    \item Spearheaded the development of a student mobile app in Flutter, scaling it to over 10,000 daily active users.
+    \item Built a student mobile app in Flutter from scratch, grew it to 10,000 daily active users.
     \item Designed and delivered technical workshops on Git and open-source best practices for first-year students.
     \item Mentored aspiring developers to contribute to major open-source projects, including the Linux kernel.
 \end{tightemize}
@@ -72,10 +72,10 @@
 \textbf{\runsubsection{\href{https://github.com/swiftlang}{SwiftLang |}}}
 \descript{The Swift programming language - \linktext{https://github.com/swiftlang/swift-build/pulls?q=is:pr+author:swiftlysingh+}{GitHub} \datetext{Present}}
 \begin{tightemize}
-    \item Implemented new diagnostic flags within the Swift build system, improving error reporting and developer experience.
+    \item Added diagnostic flags to the Swift build system for clearer compiler error messages.
     \item Enhanced compiler compatibility by adding checks for Apple Clang and removing unsupported flags.
     \item Contributed to Swift Information Architecture Project, unifying content and improving documentation accessibility.
-    \item Provided support and guidance to the Swift community on the forums, fostering collaboration and knowledge sharing.
+    \item Answered questions and helped newcomers on the Swift forums.
 \end{tightemize}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -96,8 +96,7 @@
 \begin{tightemize}
     \item Developed ArtiWeather for iOS 18 using \emphitalic{SwiftUI}, achieving \italictext{1.2k downloads} and \italictext{5k organic impressions} on launch day.
     \item Integrated \emphitalic{on-device Stable Diffusion} using \emphitalic{CoreML} for weather-based image generation, with no server costs.
-    \item Built beautiful widgets using \emphitalic{WidgetKit} for displaying weather and generated images on the home screen.
-    \item Working on optimizing SD Model, enhancing download UX/UI, and adding support for additional cities.
+    \item Added home screen widgets via \emphitalic{WidgetKit} showing live weather and AI-generated art.
 \end{tightemize}
 % \sectionsep
 
@@ -106,8 +105,7 @@
 \begin{tightemize}
     \item Built an iOS app using Swift and SwiftUI for securely storing credit and debit card details.
     \item Used iOS Keychain with iCloud sync for encrypted storage, ensuring data privacy through local-only storage.
-    \item Designed an intuitive interface with SwiftUI, providing a seamless user experience for managing card details.
-    \item Integrated biometric authentication for added security, allowing easy and secure access to stored information.
+    \item Added Face ID and Touch ID for unlocking the vault.
 \end{tightemize}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -118,8 +116,7 @@
 \textbf{\runsubsection{Smart India Hackathon 2020 |}}
 \descript{Winner \datetext{2021}}
 \begin{tightemize}
-    \item Built an AI IoT system to predict and adjust lighting and HVAC demand using sensors.
-    \item SIH is a national hackathon by the Government of India, tackling real-world challenges.
+    \item Won Smart India Hackathon 2020, a national hackathon by the Government of India. Built an AI-powered IoT system to predict and auto-adjust building lighting and HVAC using sensor data.
 \end{tightemize}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -138,16 +135,16 @@
 
 \section{Education} 
 \runsubsection{\makebox[5.6cm][l]{Master's in Computer Science} |}
-\descript{California State University \datetext{Aug '24 - May '26}}
+\descript{California State University \datetext{Aug '24 – May '26}}
 
 % \sectionsep
 
 \runsubsection{\makebox[5.6cm][l]{Technology Entrepreneurship} |}
-\descript{Stanford University  \datetext{June'25 - Aug '25}}
+\descript{Stanford University  \datetext{Jun '25 – Aug '25}}
 
 % \sectionsep
 
 \runsubsection{\makebox[5.6cm][l]{BE in Computer Engineering} |}
-\descript{Delhi University  \datetext{Aug '18 - May '22}}
+\descript{Delhi University  \datetext{Aug '18 – May '22}}
 
 \end{document}

--- a/resume.tex
+++ b/resume.tex
@@ -37,18 +37,17 @@
 \begin{tightemize}
     \item Revamped Help Center UI using \emphitalic{UIKit}, improving usability and reducing support queries by \italictext{15\%}.
     \item Drove Help Center feature rollouts across iOS, coordinating with Android, backend, and product teams.
-    \item Built a Pin-based Auth SDK in \emphitalic{Swift} with \emphitalic{VIPER}, enabling a unified experience across GoTo apps
+    \item Built a Pin-based Auth SDK in \emphitalic{Swift} with \emphitalic{VIPER}, enabling a unified experience across GoTo apps.
     \item Shipped features on the GoPay \emphitalic{Flutter} app, serving \italictext{130M daily users}.
     \item Implemented a \emphitalic{Server Driven UI} for GoPay's homepage, enabling dynamic updates without app releases.
-    \item Integrated in-house analytics framework utilizing \emphitalic{ProtoBuffs}, reducing third-party dependencies and cutting costs by 30\%.
+    \item Integrated in-house analytics framework using \emphitalic{ProtoBuffs}, reducing third-party dependencies and cutting costs by 30\%.
 \end{tightemize}
 % \sectionsep
 
 \textbf{\href{https://summerofcode.withgoogle.com/projects/6623823417311232}{\runsubsection{iOS Developer |}}} 
 \descript{Google Summer of Code - VideoLAN \datetext{Jun '21 – Aug '21}}
 \begin{tightemize}
-    \item Built the "Continue Watching" feature in VLC for iOS, letting users resume playback across sessions.
-    \item Fixed bugs and added features in VLC's \emphitalic{Objective-C} codebase.
+    \item Added the "Continue Watching" feature to VLC for iOS, letting users resume playback across sessions.
     \item Redesigned screens in \emphitalic{UIKit} to match Apple's Human Interface Guidelines.
     % \item Participated in code reviews, ensuring adherence to best practices and maintaining code quality.
     % \item Contributed to documentation, improving onboarding for new developers in the VideoLAN community.
@@ -58,7 +57,7 @@
 \textbf{\href{}{\runsubsection{Head of Open Source and Mobile Tech |}}} 
 \descript{IoSD \datetext{Jun '20 – Jun '21}}
 \begin{tightemize}
-    \item Built a student mobile app in Flutter from scratch, grew it to 10,000 daily active users.
+    \item Built a student mobile app in Flutter from scratch and grew it to 10,000 daily active users.
     \item Designed and delivered technical workshops on Git and open-source best practices for first-year students.
     \item Mentored aspiring developers to contribute to major open-source projects, including the Linux kernel.
 \end{tightemize}
@@ -91,20 +90,20 @@
 
 \section{Projects}
 
-\textbf{\href{https://apps.apple.com/app/artiweather/id6446815662}{\runsubsection{ArtiWeather |}}} 
-\descript{An Art Weather App - \linktext{https://apps.apple.com/app/artiweather/id6446815662}{AppStore}}
+\textbf{\href{https://apps.apple.com/us/app/retrobudget-ai-spend-tracker/id6743363764}{\runsubsection{RetroBudget |}}} 
+\descript{AI Spend Tracker - \linktext{https://apps.apple.com/us/app/retrobudget-ai-spend-tracker/id6743363764}{AppStore}}
 \begin{tightemize}
-    \item Developed ArtiWeather for iOS 18 using \emphitalic{SwiftUI}, achieving \italictext{1.2k downloads} and \italictext{5k organic impressions} on launch day.
-    \item Integrated \emphitalic{on-device Stable Diffusion} using \emphitalic{CoreML} for weather-based image generation, with no server costs.
-    \item Added home screen widgets via \emphitalic{WidgetKit} showing live weather and AI-generated art.
+    \item Shipped an AI spend tracker in \emphitalic{SwiftUI} as a solo project, live on the App Store with paying subscribers.
+    \item Parsed uploaded bank statements with on-device AI to categorize spending, with no data stored server-side.
+    \item Grew to \italictext{\$12 MRR} and \italictext{\$143 total revenue} using \emphitalic{RevenueCat} for subscription management.
 \end{tightemize}
 % \sectionsep
 
 \textbf{\href{https://github.com/swiftlysingh/Holder}{\runsubsection{Holder |}}} 
 \descript{A Secure Card Vault - \linktext{https://apps.apple.com/in/app/holder-a-secure-card-vault/id6475649492}{AppStore}}
 \begin{tightemize}
-    \item Built an iOS app using Swift and SwiftUI for securely storing credit and debit card details.
-    \item Used iOS Keychain with iCloud sync for encrypted storage, ensuring data privacy through local-only storage.
+    \item Created an iOS app in Swift and SwiftUI for securely storing credit and debit card details.
+    \item Used iOS Keychain with iCloud sync for end-to-end encrypted storage across devices.
     \item Added Face ID and Touch ID for unlocking the vault.
 \end{tightemize}
 
@@ -116,7 +115,8 @@
 \textbf{\runsubsection{Smart India Hackathon 2020 |}}
 \descript{Winner \datetext{2021}}
 \begin{tightemize}
-    \item Won Smart India Hackathon 2020, a national hackathon by the Government of India. Built an AI-powered IoT system to predict and auto-adjust building lighting and HVAC using sensor data.
+    \item Won Smart India Hackathon 2020, a national hackathon by the Government of India.
+    \item Built an AI-powered IoT system to predict and auto-adjust building lighting and HVAC.
 \end{tightemize}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/resume.tex
+++ b/resume.tex
@@ -102,7 +102,7 @@
 \textbf{\href{https://github.com/swiftlysingh/Holder}{\runsubsection{Holder |}}} 
 \descript{A Secure Card Vault - \linktext{https://apps.apple.com/in/app/holder-a-secure-card-vault/id6475649492}{AppStore}}
 \begin{tightemize}
-    \item Created an iOS app in Swift and SwiftUI for securely storing credit and debit card details.
+    \item Published an iOS app in Swift and SwiftUI for securely storing card details, with 8 releases and zero reported crashes.
     \item Used iOS Keychain with iCloud sync for end-to-end encrypted storage across devices.
     \item Added Face ID and Touch ID for unlocking the vault.
 \end{tightemize}

--- a/resume.tex
+++ b/resume.tex
@@ -37,10 +37,10 @@
 \begin{tightemize}
     \item Revamped Help Center UI using \emphitalic{UIKit}, improving usability and reducing support queries by \italictext{15\%}.
     \item Drove Help Center feature rollouts across iOS, coordinating with Android, backend, and product teams.
-    \item Built a Pin-based Auth SDK in \emphitalic{Swift} with \emphitalic{VIPER}, enabling a unified experience across GoTo apps.
+    \item Developed a Pin-based Auth SDK in \emphitalic{Swift} with \emphitalic{VIPER}, enabling a unified experience across GoTo apps.
     \item Shipped features on the GoPay \emphitalic{Flutter} app, serving \italictext{130M daily users}.
     \item Implemented a \emphitalic{Server Driven UI} for GoPay's homepage, enabling dynamic updates without app releases.
-    \item Integrated in-house analytics framework using \emphitalic{ProtoBuffs}, reducing third-party dependencies and cutting costs by 30\%.
+    \item Integrated in-house analytics framework using \emphitalic{Protocol Buffers}, reducing third-party dependencies and cutting costs by 30\%.
 \end{tightemize}
 % \sectionsep
 
@@ -57,7 +57,7 @@
 \textbf{\href{}{\runsubsection{Head of Open Source and Mobile Tech |}}} 
 \descript{IoSD \datetext{Jun '20 – Jun '21}}
 \begin{tightemize}
-    \item Built a student mobile app in Flutter from scratch and grew it to 10,000 daily active users.
+    \item Created a student mobile app in Flutter from scratch and grew it to 10,000 daily active users.
     \item Designed and delivered technical workshops on Git and open-source best practices for first-year students.
     \item Mentored aspiring developers to contribute to major open-source projects, including the Linux kernel.
 \end{tightemize}
@@ -74,7 +74,7 @@
     \item Added diagnostic flags to the Swift build system for clearer compiler error messages.
     \item Enhanced compiler compatibility by adding checks for Apple Clang and removing unsupported flags.
     \item Contributed to Swift Information Architecture Project, unifying content and improving documentation accessibility.
-    \item Answered questions and helped newcomers on the Swift forums.
+    \item Mentored newcomers on the Swift forums, answering technical questions on concurrency and SwiftUI.
 \end{tightemize}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -93,7 +93,7 @@
 \textbf{\href{https://apps.apple.com/us/app/retrobudget-ai-spend-tracker/id6743363764}{\runsubsection{RetroBudget |}}} 
 \descript{AI Spend Tracker - \linktext{https://apps.apple.com/us/app/retrobudget-ai-spend-tracker/id6743363764}{AppStore}}
 \begin{tightemize}
-    \item Shipped an AI spend tracker in \emphitalic{SwiftUI} as a solo project, live on the App Store with paying subscribers.
+    \item Shipped an AI spend tracker in \emphitalic{SwiftUI} as a solo project, live on the App Store.
     \item Parsed uploaded bank statements with on-device AI to categorize spending, with no data stored server-side.
     \item Monetized through \emphitalic{RevenueCat} subscriptions with paying users and zero marketing spend.
 \end{tightemize}
@@ -104,7 +104,7 @@
 \begin{tightemize}
     \item Published an iOS app in Swift and SwiftUI for securely storing card details, with 8 releases and zero reported crashes.
     \item Used iOS Keychain with iCloud sync for end-to-end encrypted storage across devices.
-    \item Added Face ID and Touch ID for unlocking the vault.
+    \item Secured the vault with Face ID and Touch ID.
 \end{tightemize}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/resume.tex
+++ b/resume.tex
@@ -40,7 +40,7 @@
     \item Developed a Pin-based Auth SDK in \emphitalic{Swift} with \emphitalic{VIPER}, enabling a unified experience across GoTo apps.
     \item Shipped features on the GoPay \emphitalic{Flutter} app, serving \italictext{130M daily users}.
     \item Implemented a \emphitalic{Server Driven UI} for GoPay's homepage, enabling dynamic updates without app releases.
-    \item Integrated in-house analytics framework using \emphitalic{Protocol Buffers}, reducing third-party dependencies and cutting costs by 30\%.
+    \item Integrated in-house analytics framework using \emphitalic{ProtoBuff}, reducing third-party dependencies and cutting costs by 30\%.
 \end{tightemize}
 % \sectionsep
 

--- a/resume.tex
+++ b/resume.tex
@@ -95,7 +95,7 @@
 \begin{tightemize}
     \item Shipped an AI spend tracker in \emphitalic{SwiftUI} as a solo project, live on the App Store with paying subscribers.
     \item Parsed uploaded bank statements with on-device AI to categorize spending, with no data stored server-side.
-    \item Grew to \italictext{\$12 MRR} and \italictext{\$143 total revenue} using \emphitalic{RevenueCat} for subscription management.
+    \item Monetized through \emphitalic{RevenueCat} subscriptions with paying users and zero marketing spend.
 \end{tightemize}
 % \sectionsep
 


### PR DESCRIPTION
Applied Karol's writing review. Swapped AI-tell verbs (Architected→Built, Engineered→Trained, Spearheaded→Built), killed filler phrases, removed in-progress bullet, compressed Awards. No structural changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized date ranges to en dash style across experience and education entries
  * Rewrote experience bullets for clearer, active, outcome-focused phrasing (solo-engineer and rollout emphasis)
  * Updated GOJEK and mobile app descriptions to highlight feature rollouts and user impact
  * Reframed Open Source guidance toward mentoring and clarified terminology
  * Renamed/rebranded projects (ArtiWeather → RetroBudget) and emphasized published apps, on-device features, encryption, and biometrics
  * Highlighted award win and reordered descriptions to emphasize outcomes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->